### PR TITLE
simplify thousands_separate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,10 +374,13 @@ impl<Spec: MCTS> MCTSManager<Spec> where ThreadData<Spec>: Default {
 // https://stackoverflow.com/questions/26998485/rust-print-format-number-with-thousand-separator
 fn thousands_separate(x: usize) -> String {
     let s = format!("{}", x);
-    let bytes: Vec<_> = s.bytes().rev().collect();
-    let chunks: Vec<_> = bytes.chunks(3).map(|chunk| String::from_utf8(chunk.to_vec()).unwrap()).collect();
-    let result: Vec<_> = chunks.join(",").bytes().rev().collect();
-    String::from_utf8(result).unwrap()
+    let chunks: Vec<&str> = s
+        .as_bytes()
+        .rchunks(3)
+        .rev()
+        .map(|chunk| std::str::from_utf8(chunk).unwrap())
+        .collect();
+    chunks.join(",")
 }
 
 #[must_use]


### PR DESCRIPTION
Very minor but this took seconds so...
Slightly reduces the number of allocations in this very non-critical function ^^